### PR TITLE
ci: Reduce cpu/memory for faster scheduling

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,8 +2,8 @@ task:
   name: "x86_64 Linux  [focal]  [system libs, no depends, fuzz, valgrind]"
   container:
     image: ubuntu:20.04
-    cpu: 8
-    memory: 24G
+    cpu: 4
+    memory: 8G
   timeout_in: 120m
   env:
     FILE_ENV: "./ci/test/00_setup_env_native_fuzz_with_valgrind.sh"
@@ -26,8 +26,8 @@ task:
   name: "x86_64 Linux  [focal]  [system libs, no depends, fuzz, sanitizers]"
   container:
     image: ubuntu:20.04
-    cpu: 8
-    memory: 24G
+    cpu: 4
+    memory: 8G
   timeout_in: 120m
   env:
     FILE_ENV: "./ci/test/00_setup_env_native_fuzz.sh"


### PR DESCRIPTION
Looking at https://cirrus-ci.com/task/4902266509459456, most of the cpu are idle