### PR TITLE
ci: Use medium workers to avoid out-of-disk issues

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,10 +3,12 @@ env:  # Global defaults
 
 task:
   name: "lint"
-  container:
-    image: ubuntu:jammy
+  compute_engine_instance:
+    disk: 50
     cpu: 1
     memory: 4G  # Needed to clone the qa-assets repo?
+    image_project: ubuntu-os-cloud
+    image: family/ubuntu-2204-lts
   use_compute_credits: $CIRRUS_REPO_OWNER == 'bitcoin-core'  # https://cirrus-ci.org/pricing/#compute-credits
   # https://cirrus-ci.org/guide/writing-tasks/#conditional-task-execution: Skip needless compute on non-pulls
   skip: $CIRRUS_PR == ""

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,12 +1,6 @@
 env:  # Global defaults
   CIRRUS_CLONE_DEPTH: 1
 
-# Use the same types as the ones defined in https://github.com/bitcoin/bitcoin/blob/master/.cirrus.yml
-persistent_worker_template_small: &PERSISTENT_WORKER_TEMPLATE_SMALL
-  persistent_worker:
-    labels:
-      type: small  # The type should not matter, but pin it to avoid non-determinism, or breakages down the line.
-
 task:
   name: "lint"
   container:
@@ -34,7 +28,9 @@ task:
   lint_script: ./out-dir/touched-files-check "HEAD~..HEAD"
 task:
   name: "[native_fuzz_with_valgrind]  [persistent_worker]"
-  << : *PERSISTENT_WORKER_TEMPLATE_SMALL
+  persistent_worker:
+    labels:
+      type: medium  # Avoid out-of-disk issues
   timeout_in: 4320m
   env:
     FILE_ENV: "./ci/test/00_setup_env_native_fuzz_with_valgrind.sh"
@@ -53,7 +49,9 @@ task:
     - ./ci/test_run_all.sh
 task:
   name: "[native_fuzz_with_msan]  [persistent_worker]"
-  << : *PERSISTENT_WORKER_TEMPLATE_SMALL
+  persistent_worker:
+    labels:
+      type: medium  # Avoid out-of-disk issues
   timeout_in: 480m
   env:
     FILE_ENV: "./ci/test/00_setup_env_native_fuzz_with_msan.sh"
@@ -75,6 +73,7 @@ task:
   persistent_worker:
     labels:
       type: medium  # Replicate config;
+  # Use the same type as the one used for native_fuzz in https://github.com/bitcoin/bitcoin/blob/master/.cirrus.yml
   timeout_in: 120m  # To catch potential timeouts early, this task must replicate the config from https://github.com/bitcoin/bitcoin/blob/master/.cirrus.yml
   env:
     FILE_ENV: "./ci/test/00_setup_env_native_fuzz.sh"


### PR DESCRIPTION
Should fix https://github.com/bitcoin-core/qa-assets/runs/16381636315:

```
Error: committing container for step {Env:[FILE_ENV=./ci/test/00_setup_env_native_fuzz_with_msan.sh PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin] Command:run Args:[bash -c cd /ci_container_base/ && set -o errexit && source ./ci/test/00_setup_env.sh && ./ci/test/01_base_install.sh] Flags:[] Attrs:map[json:true] Message:RUN bash -c cd /ci_container_base/ && set -o errexit && source ./ci/test/00_setup_env.sh && ./ci/test/01_base_install.sh Original:RUN ["bash", "-c", "cd /ci_container_base/ && set -o errexit && source ./ci/test/00_setup_env.sh && ./ci/test/01_base_install.sh"]}: copying layers and metadata for container "3f2d5964d475f12a28b9cd6f98a97df085ef6224d602cc4140d74ae084908b50": writing blob: adding layer with blob "sha256:e1dc120e1e99bbaa7de0710576a5998e3d9dafa21d6c912ed67328d4dc443b1e": processing tar file(write /msan/clang_build/lib/libclangParse.a: no space left on device): exit status 1