### PR TITLE
download_oss_fuzz_inputs.py: Use curl over wget

### DIFF
--- a/download_oss_fuzz_inputs.py
+++ b/download_oss_fuzz_inputs.py
@@ -33,7 +33,7 @@ def main():
     for target in existing_targets:
         print(f'{BOLD[1]}Downloading for target "{target}" ...{BOLD[0]}')
         url = f"https://storage.googleapis.com/bitcoin-core-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/bitcoin-core_{target}/{ZIP_NAME}"
-        if 0 != subprocess.call(["wget", url]):
+        if 0 != subprocess.call(["curl", "--fail", "--location", "--remote-name", "--retry", "3", url]):
             print(f'{BOLD[1]}... Skipping target "{target}"{BOLD[0]}')
             continue
         subprocess.check_call(["unzip", "-n", "-q", ZIP_NAME, "-d", target])


### PR DESCRIPTION
wget/wget1 apparently has issues, so that distros are switching to wget2 and alias it to `wget`, which is a breaking change here.

Fix all issues by just using `curl`, which should work everywhere.

Also, while touching the line, allow for a few retries to happen, to avoid having to re-run the whole script in a loop on flaky internet.