### PR TITLE
ci: use new cache action paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,12 +61,10 @@ jobs:
 
       - name: Restore caches
         id: restore-cache
-        uses: bitcoin/bitcoin/.github/actions/restore-caches@master
+        uses: bitcoin/bitcoin/.github/actions/cache/restore@master
 
       - name: Configure Docker
         uses: bitcoin/bitcoin/.github/actions/configure-docker@master
-        with:
-          cache-provider: 'gha'
 
       - name: CI script
         run: |
@@ -75,7 +73,7 @@ jobs:
           ./ci/test_run_all.sh
 
       - name: Save caches
-        uses: bitcoin/bitcoin/.github/actions/save-caches@master
+        uses: bitcoin/bitcoin/.github/actions/cache/save@master
 
   lint:
     name: lint


### PR DESCRIPTION
The cache action paths got renamed to accomodate warp and GHA cache actions.

Update the names here to use the new paths.