### PR TITLE
ci: Fix broken qa assets dir injection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,8 @@ jobs:
 
       - name: CI script
         run: |
-          mkdir -p ./ci/scratch/qa-assets
-          mv ./qa-assets/{.git,fuzz_corpora} ./ci/scratch/qa-assets/
+          mkdir -p "./ci/scratch_ ₿🧪_/qa-assets"
+          mv ./qa-assets/{.git,fuzz_corpora} "./ci/scratch_ ₿🧪_/qa-assets/"
           ./ci/test_run_all.sh
 
       - name: Save caches


### PR DESCRIPTION
  The upstream CI scratch directory was renamed, so the workflow must inject
  qa-assets into the new repo-relative path before the rsync step copies the
  checkout into BASE_ROOT_DIR.
