### PR TITLE
delete-nonreduced-fuzz-inputs: Fix afl -i= -o= typos

### DIFF
--- a/delete-nonreduced-fuzz-inputs/src/main.rs
+++ b/delete-nonreduced-fuzz-inputs/src/main.rs
@@ -465,8 +465,10 @@ fn run_afl_cmin<P: AsRef<Path>, Q: AsRef<Path>>(
             "-T",
             "all",
             "-A",
-            &format!("-i={}", input_dir.as_ref().display()),
-            &format!("-o={}", output_dir.display()),
+            "-i",
+            &input_dir.as_ref().display().to_string(),
+            "-o",
+            &output_dir.display().to_string(),
             "--",
             &format!("{BITCOIN_PATH}/{BITCOIN_BUILD_DIR}/bin/fuzz"),
         ])


### PR DESCRIPTION
(See commit msg)